### PR TITLE
Enable the transform tensor API to convert any NCHW tensor to NHWC tensor and vice versa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(Boost COMPONENTS filesystem REQUIRED)
 find_package(amd_comgr REQUIRED)
 
 add_subdirectory(ThirdParty/mitransform_kernels)
+add_subdirectory(ThirdParty/gputt)
 
 file(GLOB SRCS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} STATIC ${SRCS})
@@ -41,7 +42,7 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/json/include)
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_kernels roc::rocblas Boost::filesystem amd_comgr)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_kernels roc::rocblas Boost::filesystem amd_comgr gputt)
 
 add_executable(${PROJECT_NAME}_test ${CMAKE_CURRENT_SOURCE_DIR}/src/test/mitransform_test.cpp)
 target_compile_features(${PROJECT_NAME}_test PUBLIC cxx_std_17)

--- a/include/test/driver.hpp
+++ b/include/test/driver.hpp
@@ -729,6 +729,7 @@ struct test_driver
         using result_type = decltype(v.cpu(xs...));
         if(is_cache_disabled() or not is_const_cpu(v, xs...))
             return cpu_async(v, xs...);
+#if 0
         auto key = miopen::get_type_name<V>() + "-" + miopen::md5(get_command_args());
         auto p =
             boost::filesystem::path{miopen::ExpandUser(cache_path)} / std::to_string(cache_version);
@@ -745,10 +746,13 @@ struct test_driver
             });
         }
         else
+#endif
         {
             miss = true;
             return then(cpu_async(v, xs...), [=](auto data) {
+#if 0
                 save(f.string(), data);
+#endif
                 return data;
             });
         }

--- a/src/tensorocl.cpp
+++ b/src/tensorocl.cpp
@@ -2137,10 +2137,10 @@ static void find_permutation(const std::string& src_layout, const std::string& d
     std::sort(permVec.begin(), permVec.end(),
         [](const auto & a, const auto & b) -> bool
         {
-            return a.first > b.first;
+            return a.first < b.first;
         });
 
-    printf("Permutation for %s -> %s: ");
+    printf("Permutation for %s -> %s: ", src_layout.c_str(), dst_layout.c_str());
     for (int i = 0; i < permVec.size(); i++)
 	    printf("%d ", permVec[i]);
     printf("\n");
@@ -2174,7 +2174,7 @@ void TransformTensor(const Handle& handle,
         MIOPEN_THROW("Tensor dimension must be the same");
     }
 
-#if 0
+#if 1
     // Prepare to perform Y_perm(i0, i1, ...) = alpha * X{i0,i1,...} + beta * Y_perm(i0,i1,...)
     // using gpuTT library.
     auto xLayout = xDesc.GetLayout_str();

--- a/src/tensorocl.cpp
+++ b/src/tensorocl.cpp
@@ -2174,13 +2174,7 @@ void TransformTensor(const Handle& handle,
         MIOPEN_THROW("Tensor dimension must be the same");
     }
 
-    // TODO Not all layouts start with 'N', is this correct for "CHWN"?
-    if(x_len[0] != y_len[0])
-    {
-        MIOPEN_THROW("Tensor x and y batch sizes do not match");
-    }
-
-#if 1
+#if 0
     // Prepare to perform Y_perm(i0, i1, ...) = alpha * X{i0,i1,...} + beta * Y_perm(i0,i1,...)
     // using gpuTT library.
     auto xLayout = xDesc.GetLayout_str();

--- a/src/tensorocl.cpp
+++ b/src/tensorocl.cpp
@@ -35,6 +35,8 @@
 #include <cassert>
 #include <numeric>
 #include <boost/range/combine.hpp>
+#define __HIPCC__
+#include <gputt.h>
 
 #define MIO_TENSOROCL_DEBUG 0
 
@@ -2120,6 +2122,30 @@ void CastTensor(const Handle& handle,
     }
 }
 
+static void find_permutation(const std::string& src_layout, const std::string& dst_layout,
+                     int* permutation)
+{
+    std::map<char, std::pair<int, int>> permMap;
+    for (int i = 0; i < src_layout.length(); i++)
+        permMap[src_layout[i]].first = i;
+    for (int i = 0; i < dst_layout.length(); i++)
+        permMap[dst_layout[i]].second = i;
+
+    std::vector<std::pair<int, int> > permVec;
+    for (const auto &kv : permMap)
+        permVec.push_back(kv.second);
+    std::sort(permVec.begin(), permVec.end(),
+        [](const auto & a, const auto & b) -> bool
+        {
+            return a.first > b.first;
+        });
+
+    printf("Permutation for %s -> %s: ");
+    for (int i = 0; i < permVec.size(); i++)
+	    printf("%d ", permVec[i]);
+    printf("\n");
+}
+
 void TransformTensor(const Handle& handle,
                      const void* alpha,
                      const TensorDescriptor& xDesc,
@@ -2148,11 +2174,37 @@ void TransformTensor(const Handle& handle,
         MIOPEN_THROW("Tensor dimension must be the same");
     }
 
+    // TODO Not all layouts start with 'N', is this correct for "CHWN"?
     if(x_len[0] != y_len[0])
     {
         MIOPEN_THROW("Tensor x and y batch sizes do not match");
     }
 
+#if 1
+    // Prepare to perform Y_perm(i0, i1, ...) = alpha * X{i0,i1,...} + beta * Y_perm(i0,i1,...)
+    // using gpuTT library.
+    auto xLayout = xDesc.GetLayout_str();
+    auto yLayout = yDesc.GetLayout_str();
+	
+    // Remove non-capital 'c', which is not subject to a permutation
+
+    std::vector<int> permutation(x_len.size());	
+    find_permutation(xDesc.GetLayout_str(), yDesc.GetLayout_str(), permutation.data());
+
+    // Create transpose plan on NULL stream and choose implementation based on heuristics
+    // TODO Must support non-equal input and output types
+    gputtHandle plan;
+    hipStream_t stream = 0;
+    auto err = gputtPlan(&plan, x_len.size(), reinterpret_cast<int*>(x_len.data()),
+                         permutation.data(), sizeof(float), stream);
+
+    // Execute transpose plan
+    // TODO: support for alpha and beta in the case of a simple copy (i.e., perm = identity) is still missing
+    err = gputtExecute(plan, x, y, alpha, beta);
+
+    // Destroy transpose plan
+    err = gputtDestroy(plan);
+#else
     if(xDesc.GetType() == miopenInt8 && yDesc.GetType() == miopenInt8 && x_len.size() >= 3)
     {
         if(x_len[1] <= y_len[1])
@@ -2435,6 +2487,7 @@ void TransformTensor(const Handle& handle,
         default: assert(false);
         }
     }
+#endif
 }
 
 } // namespace miopen


### PR DESCRIPTION
This repository is a subset of MIOpen, which includes just the TensorTransform() implementation, a test for it, and their dependencies.

We substitute the TensorTransfom implementation with a more generic GPU-based gpuTT library calls.

Few things still to be implemented:
 * Support non-equal input and output types
 * Support for alpha and beta in the case of a simple copy (i.e., perm = identity) is still missing
 * The test should randomly transpose the input tensors, so that TensorTransform could transpose them back